### PR TITLE
Support TeamCity locator filters

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
     "env": {
         "browser": true,
-        "node": true
+        "node": true,
+        "es6": true
     },
     "extends": "eslint:recommended",
     "rules": {

--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ A configurable dashboard with a simple plugin architecture. Written in Node.js w
 
 > npm run build
 
-> nodemon app.js
+> npm start
 
 The application answers on port 3000.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "npm run test:lint --silent && mocha --recursive test/",
     "test-travis": "mocha --recursive test/",
     "build": "webpack --progress",
-    "watch": "webpack --watch"
+    "watch": "webpack --watch",
+    "watch-tests": "mocha --recursive test/ --watch"
   },
   "dependencies": {
     "angular": "^1.5.8",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test-travis": "mocha --recursive test/",
     "build": "webpack --progress",
     "watch": "webpack --watch",
-    "watch-tests": "mocha --recursive test/ --watch"
+    "watch-tests": "mocha --recursive test/ --watch",
+    "start": "nodemon app.js"
   },
   "dependencies": {
     "angular": "^1.5.8",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "eslint": "^3.7.1",
     "mocha": "^3.1.2",
+    "nodemon": "^1.11.0",
     "sinon": "^1.17.6",
     "webpack": "^1.12.9"
   }

--- a/src/plugins/teamcity/Readme.md
+++ b/src/plugins/teamcity/Readme.md
@@ -4,7 +4,6 @@ The TeamCity plugin can create widgets that display build information from a bui
 
 Datasource config
 ----
-
 To configure a connection with a TeamCity-server you need to add a new datasource to the list of datasources in server.js.
 ```
 {
@@ -18,9 +17,16 @@ To configure a connection with a TeamCity-server you need to add a new datasourc
         password: "your-teamcity-password"
       }
     },
-    url: "http://teamcityserver:8111/"
+    url: "http://teamcityserver:8111/",
+    locators: {
+      branch: "default:any", 
+      agentName: "smith"
+      }
 }
 ```
+Locators object is optional. Locators are extra filter parameters that are added to TeamCity requests. By default it gets status for all branches. 
+
+[All build locator filters for TC10](https://confluence.jetbrains.com/display/TCD10/REST+API#RESTAPI-BuildLocator)
 
 Client-side config
 ----

--- a/src/plugins/teamcity/index.js
+++ b/src/plugins/teamcity/index.js
@@ -16,7 +16,7 @@ var TeamCityPlugin = (function () {
       started: '',
       duration: '0 s',
       percent: '',
-      status: 'Success',
+      status: 'Pending',
       'class': 'inProgress'
     };
   };

--- a/src/plugins/teamcity/server.js
+++ b/src/plugins/teamcity/server.js
@@ -26,8 +26,8 @@ function teamCityRequest(datasource, path, locators) {
 function buildLocatorQueryParam(locators){
   if(!locators) return '';
 
-  var locatorString = Object.keys(locators).reduce(function(acc, val){
-    return acc.concat([`${val}:${locators[val]}`]);
+  var locatorString = Object.keys(locators).reduce(function(acc, key){
+    return acc.concat([`${key}:${locators[key]}`]);
   }, []);
   return `locator=${locatorString.join(',')}`;
 }

--- a/src/plugins/teamcity/server.js
+++ b/src/plugins/teamcity/server.js
@@ -1,12 +1,13 @@
-﻿var httpclient = require('../../../httpclient'),
-  _ = require('lodash');
+﻿var httpclient = require('../../../httpclient');
+var _ = require('lodash');
 
 var exports = module.exports = {};
 
-function teamCityRequest(datasource, url) {
+function teamCityRequest(datasource, path, locators) {
+  var locatorQueryParam = buildLocatorQueryParam(locators);
 
   var gettingTeamCityData = new Promise(function (resolve, reject) {
-    var requrl = datasource.url + 'app/rest/' + url;
+    var requrl = `${datasource.url}app/rest/${path}${locatorQueryParam}`;
     var headers = { 'Content-Type': 'application/json', 'Accept': 'application/json' };
 
     httpclient.get(requrl, datasource.auth, headers, datasource.timeout)
@@ -20,6 +21,15 @@ function teamCityRequest(datasource, url) {
   });
 
   return gettingTeamCityData;
+}
+
+function buildLocatorQueryParam(locators){
+  if(!locators) return '';
+
+  var locatorString = Object.keys(locators).reduce(function(acc, val){
+    return acc.concat([`${val}:${locators[val]}`]);
+  }, []);
+  return `locator=${locatorString.join(',')}`;
 }
 
 function findLastBuilds(runningBuilds, builds) {
@@ -53,7 +63,7 @@ function requestDetailedBuildData(datasource, builds) {
     Promise.all(detailedBuildRequests).then(function (detailedBuilds) {
       var res = JSON.stringify({
         result: 'success',
-        builds: _.map(detailedBuilds, function (build) { return JSON.parse(build); })
+        builds: detailedBuilds.map(function (build) { return JSON.parse(build); })
       });
       resolve(res);
     });
@@ -61,10 +71,13 @@ function requestDetailedBuildData(datasource, builds) {
 }
 
 function refreshDatasource(datasource, io) {
-  var eventId = datasource.plugin + '.' + datasource.id;
+  var eventId = `${datasource.plugin}.${datasource.id}`;
+  var buildPath = 'builds/?';
+  var runningLocators = Object.assign({running: 'true'}, datasource.locators);
+  var allBuildsLocators = Object.assign({defaultFilter: 'false'}, datasource.locators);
 
-  var gettingRunningBuilds = teamCityRequest(datasource, 'builds?locator=running:true');
-  var gettingBuilds = teamCityRequest(datasource, 'builds');
+  var gettingRunningBuilds = teamCityRequest(datasource, buildPath, runningLocators);
+  var gettingBuilds = teamCityRequest(datasource, buildPath, allBuildsLocators);
 
   Promise.all([gettingRunningBuilds, gettingBuilds]).then(function (results) {
     var runningBuilds = JSON.parse(results[0]);
@@ -85,7 +98,7 @@ function initDatasource(datasource, io) {
   setInterval(function() {
     refreshDatasource(datasource, io);
   }, datasource.updateInterval);
-
 }
+
 exports.name = 'teamcity';
 exports.initDatasource = initDatasource;


### PR DESCRIPTION
Adding support for locator filters so users can filter out builds by branch/id/agent/pinnedStatus etc. [All build locator filters for TC10](https://confluence.jetbrains.com/display/TCD10/REST+API#RESTAPI-BuildLocator). 
Locators are added as an object with the specific build locators as object properties.

- [x] Add support for locator filters
- [x] Add support for ES6 environment in eslint (needed for template literals)
- [x] Add npm watch-tests script
- [x] Add npm start script