### PR TITLE
Let generic server emit event update

### DIFF
--- a/src/plugins/generic/index.js
+++ b/src/plugins/generic/index.js
@@ -83,17 +83,17 @@ var GenericPlugin = (function () {
     return StringWidget(config);
   }
 
-  function getTransform(config) {
-    if (config.transform === undefined) {
-      return _.identity;
+  function getTransform(transform) {
+    if (transform && typeof(transform) === 'function') {
+      return transform;
     }
 
-    return config.transform;
+    return _.identity;
   }
 
   module.createWidget = function (config, socket) {
     var widget = createWidgetInstance(config);
-    widget.transform = getTransform(config);
+    widget.transform = getTransform(config.transform);
     setupListener(config, socket, widget);
     return widget;
   };

--- a/src/plugins/sources/appinsights/source.js
+++ b/src/plugins/sources/appinsights/source.js
@@ -7,7 +7,7 @@ var AppInsightsSource = function() {
 
   var source = {};
 
-  function validate(datasource) {
+  source.validate = function(datasource) {
     assert(datasource.source === 'app-insights',
       util.format('Datasource.source should be \'app-insights\' for datasource with id = %s.\n%s', datasource.id, JSON.stringify(datasource)));
     assert(datasource.config.endpoint !== undefined,
@@ -18,7 +18,7 @@ var AppInsightsSource = function() {
       util.format('Datasource.config.appid is missing for datasource with id = %s.\n%s', datasource.id, JSON.stringify(datasource)));
     assert(datasource.config.apikey !== undefined,
       util.format('Datasource.config.apikey is missing for datasource with id = %s.\n%s', datasource.id, JSON.stringify(datasource)));
-  }
+  };
 
   function createUri(config) {
 
@@ -60,9 +60,8 @@ var AppInsightsSource = function() {
     };
   }
 
-  function refresh(datasource, io) {
+  source.refresh = function(datasource, callback) {
 
-    var eventId = datasource.plugin + '.' + datasource.id;
     var config = datasource.config;
     
     var uri = createUri(config);
@@ -86,17 +85,12 @@ var AppInsightsSource = function() {
         return;
       }
 
-      var msg = JSON.stringify(parse(body));
+      var val = parse(body);
 
-      io.emit(eventId, msg);
+      if (callback && typeof(callback) === 'function') {
+        callback(val);
+      }
     });
-  }
-
-  source.start = function(datasource, io) {
-    validate(datasource);
-    setInterval(function() {
-      refresh(datasource, io);
-    }, datasource.updateInterval);
   };
 
   return source;

--- a/src/plugins/sources/azureservicebus/source.js
+++ b/src/plugins/sources/azureservicebus/source.js
@@ -23,15 +23,14 @@ var AzureServiceBusSource = function() {
     return token;
   };
 
-  function validate(datasource) {
+  source.validate = function(datasource) {
     assert(datasource.config.topic != undefined,
       util.format('Missing topic for Azure Service Bus datasource with id = %s', datasource.datasourceId));
     assert(datasource.config.subscription != undefined,
       util.format('Missing subscription for Azure Service Bus datasource with id = %s', datasource.datasourceId));
-  }
+  };
 
-  function refresh(datasource, io) {
-    var eventId = datasource.plugin + '.' + datasource.id;
+  source.refresh = function(datasource, callback) {
     var config = datasource.config;
 
     var uri = 'https://' + config.namespace + '.servicebus.windows.net/' + config.topic + '/Subscriptions/' + config.subscription;
@@ -71,12 +70,12 @@ var AzureServiceBusSource = function() {
         var messageCountString = result.entry.content[0].SubscriptionDescription[0].MessageCount[0];
         var messageCount = parseInt(messageCountString);
 
-        io.emit(eventId, JSON.stringify({
-          messageCount: messageCount
-        }));
+        if (callback && typeof(callback) === 'function') {
+          callback({ messageCount: messageCount });
+        }
       });
     });
-  }
+  };
 
   source.start = function(datasource, io) {
     validate(datasource);

--- a/src/plugins/sources/jsonendpoint/source.js
+++ b/src/plugins/sources/jsonendpoint/source.js
@@ -6,30 +6,27 @@ var JsonEndpointSource = function() {
 
   var source = {};
 
-  function validate(datasource) {
+  source.validate = function(datasource) {
     assert(datasource.source === 'json-endpoint',
       util.format('Datasource.source should be \'json-endpoint\' for datasource with id = %s.\n%s', datasource.id, JSON.stringify(datasource)));
     assert(datasource.config.url !== undefined,
       util.format('Datasource.config.url is missing for datasource with id = %s.\n%s', datasource.id, JSON.stringify(datasource)));
-  }
+  };
 
-  function refresh(datasource, io) {
+  source.refresh = function(datasource, callback) {
     var eventId = datasource.plugin + '.' + datasource.id;
     httpclient.get(datasource.config.url, datasource.auth, {}, datasource.timeout)
       .then(function (result) {
-        io.emit(eventId, result.body);
+        if (callback && typeof(callback) === 'function') {
+          callback(JSON.parse(result.body));
+        }
       })
       .catch(function (error) {
         console.log(util.format('JsonEndpointSource error %s : %s', datasource.id, error));
-        io.emit(eventId, undefined);
+        if (callback && typeof(callback) === 'function') {
+          callback(undefined);
+        }
       });
-  }
-
-  source.start = function(datasource, io) {
-    validate(datasource);
-    setInterval(function() {
-      refresh(datasource, io);
-    }, datasource.updateInterval);
   };
 
   return source;


### PR DESCRIPTION
Get rid of duplicate code in each data source. Let the generic server handle emitting event update. Include the opportunity to apply a transformation of the emitted JSON object.