### PR TITLE
refresh data at once when setting update interval

### DIFF
--- a/src/plugins/Readme.md
+++ b/src/plugins/Readme.md
@@ -92,13 +92,16 @@ This is a template server.js for a plugin:
 var exports = module.exports = {};
 
 function initDatasource(datasource, io) {
-  setInterval(function() {
+  function refresh() {
     var eventId = datasource.plugin + "." + datasource.id;
 
     // Here you refresh your data, and send it to the clients.
 
     io.emit(eventId, "My data")
-  }, datasource.updateInterval);
+  }
+  // set interval and fetch initial data
+  setInterval(refresh, datasource.updateInterval);
+  refresh();
 }
 
 exports.name = "plugin-name";

--- a/src/plugins/azure-servicebus/server.js
+++ b/src/plugins/azure-servicebus/server.js
@@ -27,7 +27,7 @@ var getToken = function(uri, sasKeyName, sasKey) {
 
 function initDatasource(datasource, io) {
 
-  setInterval(function() {
+  function refresh() {
     var eventId = datasource.plugin + '.' + datasource.id;
 
     var uri = 'https://' + datasource.namespace +
@@ -74,7 +74,9 @@ function initDatasource(datasource, io) {
       });
     });
 
-  }, datasource.updateInterval);
+  }
+  setInterval(refresh, datasource.updateInterval);
+  refresh();
 }
 
 exports.name = 'azure-servicebus';

--- a/src/plugins/chart/server.js
+++ b/src/plugins/chart/server.js
@@ -17,9 +17,11 @@ function refreshDatasource(datasource, io) {
 }
 
 function initDatasource(datasource, io) {
-  setInterval(function() {
+  function refresh() {
     refreshDatasource(datasource, io);
-  }, datasource.updateInterval);
+  }
+  setInterval(refresh, datasource.updateInterval);
+  refresh();
 }
 
 function validate(datasource) {

--- a/src/plugins/generic/server.js
+++ b/src/plugins/generic/server.js
@@ -49,13 +49,15 @@ function start(source, datasource, io) {
   }
   var eventId = datasource.plugin + '.' + datasource.id;
   var transform = getTransform(datasource.transform);
-  setInterval(function() {
+  function refresh() {
     source.refresh(datasource, function(value) {
       var v = transform(value);
       var msg = JSON.stringify(v);
       io.emit(eventId, msg);
     });
-  }, datasource.updateInterval);
+  }
+  setInterval(refresh, datasource.updateInterval);
+  refresh();
 }
 
 function initDatasource(datasource, io) {

--- a/src/plugins/google-analytics/server.js
+++ b/src/plugins/google-analytics/server.js
@@ -19,10 +19,11 @@ function initDatasource(datasource, io) {
     null
   );
 
-  refreshDatasource(datasource, io);
-  setInterval(function() {
+  function refresh() {
     refreshDatasource(datasource, io);
-  }, datasource.updateInterval);
+  }
+  setInterval(refresh, datasource.updateInterval);
+  refresh();
 }
 
 function gaRequest(viewId, metrics, filters, dimensions) {

--- a/src/plugins/rabbitmq/server.js
+++ b/src/plugins/rabbitmq/server.js
@@ -15,9 +15,11 @@ function refreshDatasource(datasource, io) {
 }
 
 function initDatasource(datasource, io) {
-  setInterval(function() {
+  function refresh() {
     refreshDatasource(datasource, io);
-  }, datasource.updateInterval);
+  }
+  setInterval(refresh, datasource.updateInterval);
+  refresh();
 }
 
 exports.name = 'rabbitmq';

--- a/src/plugins/simple/server.js
+++ b/src/plugins/simple/server.js
@@ -16,9 +16,11 @@ function refreshDatasource(datasource, io) {
 }
 
 function initDatasource(datasource, io) {
-  setInterval(function() {
+  function refresh() {
     refreshDatasource(datasource, io);
-  }, datasource.updateInterval);
+  }
+  setInterval(refresh, datasource.updateInterval);
+  refresh();
 }
 
 function validate(datasource) {

--- a/src/plugins/teamcity/server.js
+++ b/src/plugins/teamcity/server.js
@@ -142,9 +142,11 @@ function transformToOdashoardBuildMsg(data) {
 }
 
 function initDatasource(datasource, io) {
-  setInterval(function() {
+  function refresh() {
     refreshDatasource(datasource, io);
-  }, datasource.updateInterval);
+  }
+  setInterval(refresh, datasource.updateInterval);
+  refresh();
 }
 
 exports.name = 'teamcity';


### PR DESCRIPTION
For some data sources the update interval is set high as to avoid rate limiting etc.

When developing and testing it would be beneficial to fetch new data as soon as a data source is initialized instead of waiting for the first invocation of the update interval timeout.

## Solution

 - set interval and call the function in one go