### PR TITLE
linechart: add gradient border color feature

### DIFF
--- a/src/plugins/widgets/linechart/Readme.md
+++ b/src/plugins/widgets/linechart/Readme.md
@@ -23,7 +23,7 @@ The options object has the following fields:
 | yMin     |Number|	User defined minimum number for the yAxes scale.  |  yes |
 | yMax     |Number|	User defined maximum number for the yAxes scale.  | yes |
 | chartOptions     |Object|A [ChartJs option](http://www.chartjs.org/docs/#chart-configuration-creating-a-chart-with-options) object for all your special needs. Overwrites all default options.  |   yes |
-| datasetOptions     |Object|A [ChartJs line dataset option object](http://www.chartjs.org/docs/#line-chart-dataset-structure) object for all your special needs. Extends the default options.   |   yes |
+| datasetOptions     |Object|A [ChartJs line dataset option object](http://www.chartjs.org/docs/#line-chart-dataset-structure) object for all your special needs. Overwrites the default options.   |   yes |
 | borderColorGradientStops | string[] | hex color stops for [gradient line fill](https://blog.vanila.io/chart-js-tutorial-how-to-make-gradient-line-chart-af145e5c92f9). (Overwrites `datasetOptions.backgroundColor`) | yes |
 
 This is an example of widget config for a line chart:

--- a/src/plugins/widgets/linechart/Readme.md
+++ b/src/plugins/widgets/linechart/Readme.md
@@ -23,7 +23,8 @@ The options object has the following fields:
 | yMin     |Number|	User defined minimum number for the yAxes scale.  |  yes |
 | yMax     |Number|	User defined maximum number for the yAxes scale.  | yes |
 | chartOptions     |Object|A [ChartJs option](http://www.chartjs.org/docs/#chart-configuration-creating-a-chart-with-options) object for all your special needs. Overwrites all default options.  |   yes |
-| datasetOptions     |Object|A [ChartJs line dataset option object](http://www.chartjs.org/docs/#line-chart-dataset-structure) object for all your special needs. Overwrites all default options.   |   yes |
+| datasetOptions     |Object|A [ChartJs line dataset option object](http://www.chartjs.org/docs/#line-chart-dataset-structure) object for all your special needs. Extends the default options.   |   yes |
+| borderColorGradientStops | string[] | hex color stops for [gradient line fill](https://blog.vanila.io/chart-js-tutorial-how-to-make-gradient-line-chart-af145e5c92f9). (Overwrites `datasetOptions.backgroundColor`) | yes |
 
 This is an example of widget config for a line chart:
 

--- a/src/plugins/widgets/linechart/Readme.md
+++ b/src/plugins/widgets/linechart/Readme.md
@@ -43,4 +43,22 @@ This is an example of widget config for a line chart:
 }
 ```
 
+Example with gradient border color:
+```
+{
+  plugin: 'generic',
+  widgetType: 'linechart',
+  datasourceId: '1',
+  width: '420px',
+  height: '210px',
+  fieldName: 'number',
+  options: {
+    chartLabel: 'Fancy colors',
+    timeSeriesLength: 30,
+    borderColorGradientStops: ['lightgreen', 'orange', 'red'] // hex colors also ok
+  }
+}
+```
+![image](https://user-images.githubusercontent.com/658586/39693260-bd2907ac-51e3-11e8-9d81-17a5744a5e50.png)
+
 See also [widgets](../).

--- a/src/plugins/widgets/linechart/widget.js
+++ b/src/plugins/widgets/linechart/widget.js
@@ -95,11 +95,18 @@ var LineChartWidget = function (Chart, config) {
 
   widget.getDataset = function(inititalValues) {
 
-    var dataset = _.extend({
+    var defaultDatasetOptions = {
       backgroundColor: 'rgba(220,220,220,0.2)',
       borderColor: '#27ae60',
       pointRadius: 0
-    }, widget.datasetOptions || {});
+    };
+
+    var dataset;
+    if (widget.datasetOptions) {
+      dataset = widget.datasetOptions;
+    } else {
+      dataset = _.cloneDeep(defaultDatasetOptions);
+    }
 
     dataset.label = widget.chartLabel;
     dataset.data = inititalValues;

--- a/src/plugins/widgets/linechart/widget.js
+++ b/src/plugins/widgets/linechart/widget.js
@@ -21,8 +21,30 @@ var LineChartWidget = function (Chart, config) {
     yMin: config.options.yMin,
     yMax: config.options.yMax,
     chartOptions: config.options.chartOptions,
-    datasetOptions: config.options.datasetOptions
+    datasetOptions: config.options.datasetOptions,
+    borderColorGradientStops: config.options.borderColorGradientStops
   };
+
+  function updateBorderGradient() {
+    const borderColorGradientStops = widget.borderColorGradientStops;
+    const chart = widget.chart;
+    
+    if(!borderColorGradientStops || !chart) {
+      return;
+    }
+      
+    // create gradient over chart area
+    const area = chart.chartArea;
+    const gradientStroke = chart.ctx.createLinearGradient(0, area.bottom, 0, area.top);
+    // add defined color stops
+    const length = borderColorGradientStops.length;
+    borderColorGradientStops.forEach((color, idx) => {
+      const stop = 1/(length-1)*idx;
+      gradientStroke.addColorStop(stop, color);
+    });
+
+    chart.data.datasets[0].borderColor = gradientStroke;
+  }
 
   widget.update = function(value) {
     if (widget.chart == null) {
@@ -39,6 +61,10 @@ var LineChartWidget = function (Chart, config) {
         labels.shift();
         data.shift();
       }
+
+      // can only apply gradient when
+      // chart area has already been calculated
+      updateBorderGradient();
 
       widget.chart.update();
     }
@@ -69,18 +95,11 @@ var LineChartWidget = function (Chart, config) {
 
   widget.getDataset = function(inititalValues) {
 
-    var defaultDatasetOptions = {
+    var dataset = _.extend({
       backgroundColor: 'rgba(220,220,220,0.2)',
       borderColor: '#27ae60',
       pointRadius: 0
-    };
-
-    var dataset;
-    if (widget.datasetOptions) {
-      dataset = widget.datasetOptions;
-    } else {
-      dataset = _.cloneDeep(defaultDatasetOptions);
-    }
+    }, widget.datasetOptions || {});
 
     dataset.label = widget.chartLabel;
     dataset.data = inititalValues;


### PR DESCRIPTION
Sometimes it really helps to visually distinguish values in charts based on a color.

This feature adds the ability (via option `borderColorGradientStops`) to set a gradient for linechart so that we can do something like this:

![image](https://user-images.githubusercontent.com/658586/39693260-bd2907ac-51e3-11e8-9d81-17a5744a5e50.png)

Config for this example:
```js
const plugin = {
	plugin: 'generic',
    widgetType: 'linechart',
    datasourceId: '1',
    width: '420px',
    height: '210px',
    fieldName: 'number',
    options: {
      chartLabel: 'Numbers',
      timeSeriesLength: 30,
      borderColorGradientStops: ['lightgreen', 'orange', 'red'] // hex colors also ok
    }
}
```

## Solution

The gradient overrides the setting `datasetOptions.bordeColor` by creating a gradient based on the chart area (`widget.chart.chartArea`) so that the first color in the array is painted at the bottom of the graph and the last one at the top.

The color stops are defined with option `borderColorGradientStops`.
