### PR TITLE
allow to set auto start of tab cycle via config

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -196,6 +196,14 @@ var dashboardConfig = {
 ```
 
 If both `tabs` and `rows` are present, `tabs` will be used.
+
+### Tab cycling
+
+In `config/appconfig.js` you'll find 2 settings
+ * `tabCycleAutoStart: boolean` - control if cycle is started automatically or not
+ * `tabCycleInterval: number` - control the time to spend on each tab (milliseconds)
+
+
 ## Why another dashboard?
 
 Odashboard origins from a hackathon at NRK. We wanted to display build information from TeamCity together with queue information from RabbitMQ on a big screen in our office. Instead of looking to existing open source dashboards like Dashing, we wanted to get some experience with Node.js, and thus Odashboard was born. At first it was a hard coded mess, but over time it evolved to the plugin oriented configurable application it is today. And then we thought other people might enjoy it as much as we do, so we open sourced it.

--- a/config/appconfig.js
+++ b/config/appconfig.js
@@ -11,5 +11,6 @@ module.exports = {
   datasourceDefaults: datasourceDefaults,
   widgetDefaults: widgetDefaults,
   enabledPlugins: ['teamcity', 'rabbitmq', 'simple', 'iframe', 'azure-servicebus', 'image', 'chart', 'google-analytics', 'generic'],
-  tabCycleInterval: 7000
+  tabCycleInterval: 7000,
+  tabCycleAutoStart: false
 };

--- a/src/controllers.js
+++ b/src/controllers.js
@@ -38,7 +38,11 @@ var myController = app.controller('PluginController', function($rootScope, $scop
       tabCycle = $interval(function() {
         $scope.nextTab();
       }, config.tabCycleInterval);
-    };    
+    };
+
+    if(config.tabCycleAutoStart) {
+      $scope.startTabCycle();
+    }
   }, function errorCallback(response) {
     console.log('Could not find widget config');
   });


### PR DESCRIPTION
To support the case when you have the dashboard displayed via something that lacks input devices it would be beneficial to be able to start the tab cycle via configuration instead of click.

## Solution

Add config `tabCycleAutoStart: boolean` to `config/appconfig.js` and corresponding logic to `src/controller.js`