### PR TITLE
Bug: require keyFile for ga-plugin crashes

### DIFF
--- a/src/plugins/google-analytics/server.js
+++ b/src/plugins/google-analytics/server.js
@@ -1,6 +1,7 @@
 var google = require('googleapis');
 var _ = require('lodash');
 var util = require('util');
+var path = require('path');
 
 var analytics = google.analytics('v3');
 var validator = require('./validator');
@@ -10,7 +11,11 @@ var authClient;
 
 function initDatasource(datasource, io) {
 
-  var key = require('../../../config/' + datasource.keyFile);
+  // keyFile can be string or actual object
+  var key = typeof datasource.keyFile === 'string'
+    ? require(path.join(process.cwd(), 'config', datasource.keyFile))
+    : datasource.keyFile;
+  
   authClient = new google.auth.JWT(
     key.client_email,
     null,

--- a/src/plugins/sources/google-analytics/source.js
+++ b/src/plugins/sources/google-analytics/source.js
@@ -1,7 +1,8 @@
-var util = require('util'),
-  assert = require('assert'),
-  google = require('googleapis'),
-  _ = require('lodash');
+var path = require('path');
+var util = require('util');
+var assert = require('assert');
+var google = require('googleapis');
+var _ = require('lodash');
 
 var analytics = google.analytics('v3');
 var authClient;
@@ -34,7 +35,11 @@ var GoogleAnalyticsSource = function() {
   };
 
   source.start = function(datasource) {
-    var key = require('../../../../config/' + datasource.config.keyFile);
+    
+    var key = typeof datasource.config.keyFile === 'string'
+      ? require(path.join(process.cwd(), 'config', datasource.config.keyFile))
+      : datasource.config.keyFile;
+    
     authClient = new google.auth.JWT(
       key.client_email,
       null,


### PR DESCRIPTION
## Reason
The root path when running odash as dependency is not found at `../../../config`, but can be found using `path.join(process.cwd(), 'config')`.

## Solution

 - use path.join and process.cwd() to get keyFile path
 - allow passing keyFile as an object